### PR TITLE
docs/physical/2002: some databases do allow extending enums

### DIFF
--- a/docs/physical/2002.md
+++ b/docs/physical/2002.md
@@ -6,8 +6,8 @@ but internally the column is stored as the ordinal number of the string
 in the enumerated list. The storage is therefore compact, but when you
 sort a query by this column, the result is ordered by the ordinal value,
 not alphabetically by the string value. You may not expect this behavior.
-There's no syntax to add or remove a value from an ENUM or check constraint
-you can only redefine the column with a new set of values.
+Not all databases allow you to add or remove a value from an ENUM or check
+constraint; you can only redefine the column with a new set of values.
 Moreover, if you make a value obsolete, you could upset historical data.
 As a matter of policy, changing metadata — that is, changing the definition
 of tables and columns—should be infrequent and with attention to testing and


### PR DESCRIPTION
- closes #8 Values In Definition: syntax to add or remove a value from an ENUM

 as requested by @jarulraj, i have rewritten the warning message