### PR TITLE
Fixed true_pattern regular expression of CheckSpaghettiQuery

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -771,7 +771,7 @@ void CheckSpaghettiQuery(Configuration& state,
                          const std::string& sql_statement,
                          bool& print_statement){
 
-  std::regex true_pattern(".*");
+  std::regex true_pattern(".+");
   std::regex false_pattern("pattern must not exist");
   std::regex pattern;
 


### PR DESCRIPTION
Hi, I've found infinite loop on CheckSpaghettiQuery.

`true_pattern` `.*` matches empty string and it causes infinite loop (may be same case on [this](https://stackoverflow.com/questions/36049477/why-is-my-regex-causing-an-infinite-loop) ).
I believe `true_pattern` should be changed to `.+`.