### PR TITLE
Raise high risk warning when not checking for equality when doing joins

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -309,6 +309,8 @@ void CheckStatement(Configuration& state,
 
   CheckSelectStar(state, statement, print_statement);
 
+  CheckJoinWithoutEquality(state, statement, print_statement);
+
   CheckNullUsage(state, statement, print_statement);
 
   CheckNotNullUsage(state, statement, print_statement);

--- a/src/include/list.h
+++ b/src/include/list.h
@@ -64,6 +64,10 @@ void CheckSelectStar(Configuration& state,
                      const std::string& sql_statement,
                      bool& print_statement);
 
+void CheckJoinWithoutEquality(Configuration& state,
+                              const std::string& sql_statement,
+                              bool& print_statement);
+
 void CheckNullUsage(Configuration& state,
                     const std::string& sql_statement,
                     bool& print_statement);

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -576,6 +576,28 @@ void CheckSelectStar(Configuration& state,
 
 }
 
+void CheckJoinWithoutEquality(Configuration& state,
+                              const std::string& sql_statement,
+                              bool& print_statement) {
+  std::regex pattern("join[\\s\\._]?[^=]+?(left|right|join|where|case)");
+  std::string title = "JOIN Without Equality Check";
+  PatternType pattern_type = PatternType::PATTERN_TYPE_QUERY;
+
+  auto message =
+      "● Use = with JOIN: "
+      "JOIN should always have an equality check to ensure proper scope of records. ";
+
+  CheckPattern(state,
+               sql_statement,
+               print_statement,
+               pattern,
+               RISK_LEVEL_HIGH,
+               pattern_type,
+               title,
+               message,
+               true);
+}
+
 void CheckNullUsage(Configuration& state,
                     const std::string& sql_statement,
                     bool& print_statement) {

--- a/test/test_suite.cpp
+++ b/test/test_suite.cpp
@@ -456,5 +456,23 @@ TEST(TestSuite, QueryTests) {
 
 }
 
+TEST(TestSuite, JoinEqualityTest) {
+    Configuration default_conf;
+    default_conf.testing_mode = true;
+    default_conf.verbose = true;
+
+    std::unique_ptr<std::istringstream> stream(new std::istringstream());
+    stream->str(
+            "SELECT baz.id\n"
+            "FROM foo\n"
+            "LEFT JOIN bar ON bar\n"
+            "JOIN baz ON baz = foo.baz;"
+    );
+
+    default_conf.test_stream.reset(stream.release());
+
+    Check(default_conf);
+
+}
 
 }  // End machine sqlcheck


### PR DESCRIPTION
It seems that it would be useful to be able to raise high risk notices when running any form of `join` without an equality check on the join.

Example:
```sql
SELECT baz.id
FROM foo
JOIN bar ON bar
LEFT JOIN baz on bar.id = baz.bar_id;
```

`bar` has no equality checking criteria so it will simply join all the records regardless of relation.