### PR TITLE
Exit code when sqlcheck has completed checking for antipatterns

### DIFF
--- a/src/checker.cpp
+++ b/src/checker.cpp
@@ -12,7 +12,7 @@
 #include <regex>
 #include <map>
 
-#include "checker.h"
+#include "include/checker.h"
 
 #include "include/configuration.h"
 #include "include/list.h"
@@ -20,8 +20,9 @@
 
 namespace sqlcheck {
 
-void Check(Configuration& state) {
+bool Check(Configuration& state) {
 
+  bool has_issues = false;
   std::unique_ptr<std::istream> input;
 
   // Set up stream
@@ -79,12 +80,15 @@ void Check(Configuration& state) {
     std::cout << ">  Medium Risk :: " << state.checker_stats[RISK_LEVEL_MEDIUM] << "\n";
     std::cout << ">  Low Risk    :: " << state.checker_stats[RISK_LEVEL_LOW] << "\n";
     std::cout << ">  Hints       :: " << state.checker_stats[RISK_LEVEL_NONE] << "\n";
+    has_issues = true;
   }
 
   // Skip destroying std::cin
   if (state.file_name.empty()) {
     input.release();
   }
+
+  return has_issues;
 
 }
 

--- a/src/include/checker.h
+++ b/src/include/checker.h
@@ -9,7 +9,7 @@
 namespace sqlcheck {
 
 // Check a set of SQL statements
-void Check(Configuration& state);
+bool Check(Configuration& state);
 
 // Check a SQL statement
 void CheckStatement(Configuration& state,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,6 +97,8 @@ void Usage() {
 
 int main(int argc, char **argv) {
 
+  bool has_issues = false;
+
   try {
 
     // Parse the input arguments from the user
@@ -118,7 +120,7 @@ int main(int argc, char **argv) {
     ConfigureChecker(sqlcheck::state);
 
     // Invoke the checker
-    sqlcheck::Check(sqlcheck::state);
+    has_issues = sqlcheck::Check(sqlcheck::state);
 
   }
   // Catching at the top level ensures that
@@ -130,5 +132,6 @@ int main(int argc, char **argv) {
   }
 
   gflags::ShutDownCommandLineFlags();
-  return (EXIT_SUCCESS);
+
+  (has_issues) ? exit(EXIT_FAILURE) : exit(EXIT_SUCCESS);
 }


### PR DESCRIPTION
Fixes #22 

I agree with the original reporter, exit codes are very helpful for CI operations to prevent a build from showing as successful when sqlcheck fails.