### PR TITLE
Fix `gcc-13` build faiulure (missing `<cstdint>` include)

### DIFF
--- a/src/include/configuration.h
+++ b/src/include/configuration.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Without the change build against `gcc-13` fails as:

    In file included from /build/sqlcheck/src/configuration.cpp:3:
    /build/sqlcheck/src/include/configuration.h:88:8: error: 'uint32_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
       88 |   std::uint32_t line_number;
          |        ^~~~~~~~
          |        wint_t